### PR TITLE
supporting response docs for mongo 2.2+

### DIFF
--- a/src/emongo.erl
+++ b/src/emongo.erl
@@ -102,16 +102,13 @@ do_auth(Nonce, Pid, Pool, User, Pass) ->
     Packet = emongo_packet:do_query(Pool#pool.database, "$cmd", Pool#pool.req_id, Query),
 
     Resp = emongo_conn:send_recv(Pid, Pool#pool.req_id, Packet, ?TIMEOUT),
-    case lists:nth(1, Resp#response.documents) of
-        [{<<"ok">>, 1.0}] ->
-            {ok, authenticated};
-        L ->
-            case lists:keyfind(<<"errmsg">>, 1, L) of
-                false ->
-                    throw(no_error_message);
-                {<<"errmsg">>, Error} ->
-                    throw(Error)
-            end
+    [RespDoc] = Resp#response.documents,
+    case proplists:get_value(<<"ok">>, RespDoc) of
+        1.0 -> {ok, authenticated};
+        _ -> case proplists:get_value(<<"errmsg">>, RespDoc) of
+            undefined -> throw(no_error_message);
+            Error -> throw(Error)
+        end
     end.
 
 getnonce(Pid, Pool) ->


### PR DESCRIPTION
Hello :)

I was trying to login to mongo versions 2.2 and 2.4 without success. What I found is that the response on those versions have many docs (more than version 2.0), so the <<"ok">> msg could not be found. Example:

For 2.0, we get:

``` erlang
[
  [{<<"ok">>,1.0}]
]
```

For 2.2 and 2.4, we get:

``` erlang
[[
  {<<"dbname">>,<<"blog">>},
  {<<"user">>,<<"root">>},
  {<<"readOnly">>,false},
  {<<"ok">>,1.0}
]]
```

The fix will not assume that we get only one element in the response list, tested with 2.0, 2.2, and 2.4, so I hope it is acceptable.

Cheers,
