### PR TITLE
Added emongo_utils to .app file

### DIFF
--- a/ebin/emongo.app
+++ b/ebin/emongo.app
@@ -6,7 +6,8 @@
 		emongo_app,
 		emongo_bson,
 		emongo_conn,
-		emongo_packet
+		emongo_packet,
+		emongo_utils
     ]},
     {registered, []},
     {mod, {emongo_app, []}},


### PR DESCRIPTION
This fixes rebar compile failing

```
$ rebar --version
rebar 2.2.0 R16B02 20140407_103552 No VCS info available.
# I also found this with R17 though

$ rebar compile
==> emongo (compile)
Compiled src/emongo_utils.erl
Compiled src/emongo_app.erl
Compiled src/emongo_packet.erl
Compiled src/emongo_conn.erl
Compiled src/emongo_bson.erl
Compiled src/emongo.erl
ERROR: One or more .beam files exist that are not listed in emongo.app:
    * emongo_utils
ERROR: compile failed while processing /home/ubuntu/*****/deps/emongo: rebar_abort
```
